### PR TITLE
docs: actualizar guia del proyecto

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Llaves públicas de Supabase
+VITE_SUPABASE_URL="https://your-project.supabase.co"
+VITE_SUPABASE_PUBLISHABLE_KEY="your-public-anon-key"

--- a/README.md
+++ b/README.md
@@ -1,73 +1,83 @@
-# Welcome to your Lovable project
+# InnoTech Agents Platform
 
-## Project info
+Catálogo web para descubrir, analizar y gestionar agentes de IA listos para usar. La aplicación ofrece una experiencia completa desde el landing page hasta el panel privado, con datos servidos por Supabase.
 
-**URL**: https://lovable.dev/projects/fad6a938-9a8d-48f7-bf36-d86b41d780d4
+## Características principales
+- **Landing orientada a conversión**: hero en español, llamadas a la acción y agentes destacados cargados desde Supabase.
+- **Exploración avanzada**: buscador en vivo, filtros por tipo de categoría (profesión o necesidad) y contador de resultados.
+- **Detalle de agente**: ficha enriquecida con configuración del modelo, pasos de workflow, categorías asociadas y acciones rápidas.
+- **Autenticación Supabase**: registro, inicio de sesión y cierre de sesión con preservación de sesión en el navegador.
+- **Dashboard del creador**: métricas de uso, costos estimados, satisfacción promedio y listado de agentes propios.
 
-## How can I edit this code?
+## Tecnologías
+- [Vite](https://vitejs.dev/) + [React 18](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/)
+- [Tailwind CSS](https://tailwindcss.com/) y componentes de [shadcn/ui](https://ui.shadcn.com/)
+- [@tanstack/react-query](https://tanstack.com/query/latest) para manejo de caché de datos
+- [Supabase](https://supabase.com/) como backend (autenticación, base de datos Postgres y almacenamiento)
 
-There are several ways of editing your application.
-
-**Use Lovable**
-
-Simply visit the [Lovable Project](https://lovable.dev/projects/fad6a938-9a8d-48f7-bf36-d86b41d780d4) and start prompting.
-
-Changes made via Lovable will be committed automatically to this repo.
-
-**Use your preferred IDE**
-
-If you want to work locally using your own IDE, you can clone this repo and push changes. Pushed changes will also be reflected in Lovable.
-
-The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
-
-Follow these steps:
-
-```sh
-# Step 1: Clone the repository using the project's Git URL.
-git clone <YOUR_GIT_URL>
-
-# Step 2: Navigate to the project directory.
-cd <YOUR_PROJECT_NAME>
-
-# Step 3: Install the necessary dependencies.
-npm i
-
-# Step 4: Start the development server with auto-reloading and an instant preview.
-npm run dev
+## Estructura relevante
+```text
+src/
+  assets/               Recursos estáticos (p. ej. hero-bg)
+  components/           UI reutilizable (Navbar, AgentCard, etc.)
+  hooks/                Hooks personalizados
+  integrations/
+    supabase/           Cliente generado y tipado Database
+  lib/                  Contextos y utilidades (AuthProvider)
+  pages/                Rutas principales (Home, Explore, Dashboard...)
+public/                 Archivos servidos por Vite
+supabase/               Configuración de proyecto y migraciones SQL
 ```
 
-**Edit a file directly in GitHub**
+## Requisitos previos
+- Node.js 18 o superior (se recomienda usar `nvm`)
+- Cuenta y proyecto en Supabase para obtener las llaves públicas
+- [Supabase CLI](https://supabase.com/docs/guides/cli) opcional para ejecutar migraciones en local
 
-- Navigate to the desired file(s).
-- Click the "Edit" button (pencil icon) at the top right of the file view.
-- Make your changes and commit the changes.
+## Configuración local
+1. Instala dependencias:
+   ```bash
+   npm install
+   ```
+2. Copia el archivo de variables de entorno y complétalo:
+   ```bash
+   cp .env.example .env
+   ```
+   Variables utilizadas:
+   - `VITE_SUPABASE_URL`
+   - `VITE_SUPABASE_PUBLISHABLE_KEY`
+3. Ejecuta el entorno de desarrollo:
+   ```bash
+   npm run dev
+   ```
+4. Para revisar estilos con Tailwind y componentes, mantén abierto el servidor en `http://localhost:5173`.
 
-**Use GitHub Codespaces**
+## Supabase y base de datos
+- El cliente se crea en `src/integrations/supabase/client.ts` con tipado generado automáticamente.
+- El esquema disponible en `src/integrations/supabase/types.ts` refleja las tablas principales (`agents`, `categories`, `agent_executions`, etc.).
+- Migraciones SQL ubicadas en `supabase/migrations/`. Puedes aplicarlas con la CLI:
+  ```bash
+  supabase link --project-ref <project_id>
+  supabase db push
+  ```
+  El `project_id` por defecto se encuentra en `supabase/config.toml`.
 
-- Navigate to the main page of your repository.
-- Click on the "Code" button (green button) near the top right.
-- Select the "Codespaces" tab.
-- Click on "New codespace" to launch a new Codespace environment.
-- Edit files directly within the Codespace and commit and push your changes once you're done.
+Consulta la guía detallada del modelo de datos en [`docs/data-model.md`](docs/data-model.md).
 
-## What technologies are used for this project?
+## Scripts disponibles
+- `npm run dev`: servidor de desarrollo con Vite.
+- `npm run build`: compilación para producción.
+- `npm run build:dev`: build en modo desarrollo (útil para validar warnings).
+- `npm run preview`: previsualización del build.
+- `npm run lint`: ejecuta ESLint sobre el código fuente.
 
-This project is built with:
+## Buenas prácticas del proyecto
+- Mantener el tipado estricto al interactuar con Supabase reutilizando los tipos generados (`Database`).
+- Usar `@tanstack/react-query` para llamadas que requieran caché o estados de carga.
+- Seguir la paleta y componentes base definidos en shadcn/ui para consistencia visual.
+- Validar formularios con `zod` tal como se realiza en la página de autenticación.
 
-- Vite
-- TypeScript
-- React
-- shadcn-ui
-- Tailwind CSS
-
-## How can I deploy this project?
-
-Simply open [Lovable](https://lovable.dev/projects/fad6a938-9a8d-48f7-bf36-d86b41d780d4) and click on Share -> Publish.
-
-## Can I connect a custom domain to my Lovable project?
-
-Yes, you can!
-
-To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
-
-Read more here: [Setting up a custom domain](https://docs.lovable.dev/features/custom-domain#custom-domain)
+## Próximos pasos sugeridos
+- Implementar acciones pendientes en la ficha del agente (clonar, personalizar, ejecutar demo).
+- Completar el flujo de creación de agentes desde el dashboard.
+- Añadir pruebas end-to-end una vez se estabilice la API.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,120 @@
+# Modelo de datos
+
+El proyecto utiliza Supabase (Postgres) como backend. A continuación se describen las tablas principales y cómo las consume el frontend.
+
+## Diagramas y relaciones clave
+
+```
+profiles 1---* agents *---* categories
+    |             |  \\       \\
+    |             |   \\       agent_categories
+    |             |    \\
+    |             |     * agent_executions
+    |             \\
+    * collections
+```
+
+- `profiles` es la fuente de verdad para la información del usuario autenticado.
+- `agents` almacena la definición completa del agente IA.
+- `categories` clasifica los agentes por profesión o necesidad; la relación `agent_categories` resuelve el vínculo N:M.
+- `agent_executions` guarda métricas de uso (tiempo, costo, satisfacción).
+- `agent_customizations` permitirá que cada usuario guarde variantes personalizadas.
+- `collections` agrupa agentes creados por un mismo usuario.
+
+## Tablas
+
+### profiles
+| Campo | Tipo | Descripción |
+| --- | --- | --- |
+| `id` | `uuid` | Identificador del usuario (coincide con `auth.users`). |
+| `email` | `text` | Email principal. |
+| `full_name` | `text` | Nombre visible en el dashboard. |
+| `avatar_url` | `text` | URL del avatar opcional. |
+| `role` | `enum(user_role)` | Rol (admin, creator, client). |
+| `created_at`, `updated_at` | `timestamptz` | Timestamps de auditoría. |
+
+Uso en frontend: la página `Dashboard` obtiene `profiles` para saludar al usuario.
+
+### agents
+| Campo | Tipo | Descripción |
+| --- | --- | --- |
+| `id` | `uuid` | Identificador del agente. |
+| `name` | `text` | Nombre comercial mostrado en tarjetas y detalle. |
+| `description` | `text` | Resumen mostrado en la UI. |
+| `creator_id` | `uuid` | Relación con `profiles.id`. |
+| `collection_id` | `uuid` | Agrupación opcional (`collections`). |
+| `status` | `enum(agent_status)` | `draft`, `published` o `archived`. |
+| `tags` | `text[]` | Etiquetas visibles en tarjetas y detalle. |
+| `system_prompt` | `text` | Prompt base utilizado por el modelo. |
+| `workflow_steps` | `jsonb` | Lista ordenada de pasos mostrada en la ficha. |
+| `llm_provider`, `temperature`, `top_p`, `max_tokens` | `text`/`numeric` | Configuración del modelo. |
+| `input_schema`, `output_schema`, `tools` | `jsonb` | Estructuras avanzadas para integraciones. |
+| `language` | `text` | Idioma principal del agente. |
+| `created_at`, `updated_at`, `version` | `timestamptz`/`int` | Control de versiones. |
+
+Consultas relevantes:
+- `Home` y `Explore` cargan agentes publicados y agregan el conteo de ejecuciones.
+- `AgentDetail` expone la configuración completa usando joins con `profiles`, `collections` y `categories`.
+
+### categories
+| Campo | Tipo | Descripción |
+| --- | --- | --- |
+| `id` | `uuid` | Identificador. |
+| `name` | `text` | Nombre mostrado en filtros. |
+| `description` | `text` | Texto descriptivo opcional. |
+| `icon` | `text` | Nombre de icono (pendiente de uso en UI). |
+| `type` | `enum(category_type)` | `profession` o `need`. |
+| `created_at` | `timestamptz` | Fecha de creación. |
+
+Uso en frontend: `Explore` permite filtrar por tipo y categoría específica.
+
+### agent_categories
+Tabla pivote que relaciona agentes con categorías.
+
+| Campo | Tipo | Descripción |
+| --- | --- | --- |
+| `agent_id` | `uuid` | FK a `agents`. |
+| `category_id` | `uuid` | FK a `categories`. |
+
+### agent_executions
+| Campo | Tipo | Descripción |
+| --- | --- | --- |
+| `id` | `uuid` | Identificador de la ejecución. |
+| `agent_id` | `uuid` | Referencia al agente ejecutado. |
+| `user_id` | `uuid` | Usuario que lanzó la ejecución. |
+| `estimated_cost` | `numeric` | Costo aproximado en tokens o USD. |
+| `execution_time_ms` | `integer` | Duración en milisegundos. |
+| `satisfaction_rating` | `integer` | Calificación 1-5. |
+| `feedback` | `text` | Comentario libre. |
+| `input_data`, `output_data` | `jsonb` | Payload de entrada y salida (opcional). |
+| `created_at` | `timestamptz` | Fecha de la ejecución. |
+
+Uso en frontend: `Dashboard` agrega costo total, total de ejecuciones y promedio de satisfacción.
+
+### agent_customizations
+Permite a los usuarios guardar configuraciones personalizadas de un agente base.
+
+| Campo | Tipo | Descripción |
+| --- | --- | --- |
+| `id` | `uuid` | Identificador. |
+| `agent_id` | `uuid` | Relación con `agents`. |
+| `user_id` | `uuid` | Usuario propietario. |
+| `custom_config` | `jsonb` | Payload con overrides (prompts, parámetros, etc.). |
+| `created_at`, `updated_at` | `timestamptz` | Seguimiento de cambios. |
+
+### collections
+| Campo | Tipo | Descripción |
+| --- | --- | --- |
+| `id` | `uuid` | Identificador. |
+| `creator_id` | `uuid` | Propietario (`profiles`). |
+| `name` | `text` | Nombre visible de la colección. |
+| `description` | `text` | Descripción opcional. |
+| `thumbnail_url` | `text` | Imagen representativa. |
+| `is_public` | `boolean` | Indica si la colección es pública. |
+| `created_at`, `updated_at` | `timestamptz` | Fechas de control. |
+
+## Buenas prácticas para la base de datos
+- Utiliza los tipos generados (`Database`) al llamar `createClient` para mantener autocompletado y validaciones.
+- Prefiere `select` tipados (`supabase.from<'agents'>`) cuando agregues nuevas consultas.
+- Considera políticas RLS en Supabase para restringir acceso según `role` antes de publicar.
+- Versiona cualquier cambio en SQL dentro de `supabase/migrations` para mantener coherencia entre entornos.


### PR DESCRIPTION
## Summary
- reemplazar el README genérico por una guía en español que describe funcionalidades, stack y configuración local
- añadir plantilla `.env.example` con las variables públicas necesarias para conectar Supabase
- documentar el modelo de datos consumido por el frontend en `docs/data-model.md`

## Testing
- no tests were run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e09b12d1948321a8c64c4390d94a33